### PR TITLE
feat : possibility to change the newline split for different file format

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,14 @@
 const fs = require("fs")
 
 class RecordManager {
-    constructor(recordFilePath=undefined) {
+    constructor(recordFilePath = undefined) {
         this.recordFilePath = recordFilePath
         this.rawData = undefined
         this.rawDataList = undefined
         this.parsedData = undefined
         this.removeCommentsRegex = /\\"|"(?:\\"|[^"])*"|((^|[^\\])\;((?!(#)).)*)/g
-        this.removeBlankLineRegex = /^(?:[\t ]*(?:\r?\n|\r))+/gm 
+        this.removeBlankLineRegex = /^(?:[\t ]*(?:\r?\n|\r))+/gm
+        this.splitByNewLineStr = '\r'
         //
         this.recordTemplate = {
             mx: "{name}\tIN\tMX\t{preference}\t{host}\t ;#{id}\n",
@@ -22,7 +23,7 @@ class RecordManager {
         this.generatorPattern = "{origin}\n{ttl}\n\n; SOA Record\n{soa}\n; NS Records\n{ns}\n\n; MX Records\n{mx}\n\n; A Records\n{a}\n\n; AAAA Records\n{aaaa}\n\n; CNAME Records\n{cname}\n\n; TXT Records\n{txt}\n\n; SRV Records\n{srv}"
     }
 
-    setRawData(rawData=undefined) {
+    setRawData(rawData = undefined) {
         this.rawData = rawData ? rawData : fs.readFileSync(this.recordFilePath, 'utf-8')
     }
 
@@ -44,6 +45,14 @@ class RecordManager {
 
     setRemoveBlankLineRegex(regex) {
         this.removeBlankLineRegex = regex
+    }
+
+    setSplitByNewLineStr(str) {
+        this.splitByNewLineStr = str;
+    }
+
+    getSplitByNewLineStr() {
+        return this.splitByNewLineStr;
     }
 
     setRawDataList(list) {
@@ -73,7 +82,7 @@ class RecordManager {
     getGeneratorPattern() {
         return this.generatorPattern
     }
-    
+
     setGeneratorPattern(string) {
         this.generatorPattern = string
     }
@@ -106,8 +115,8 @@ class RecordManager {
     }
 
     splitRecords() {
-        let recordList = this.getRawData().split('\n')
-        if(recordList[recordList.length - 1] === '') recordList.pop()
+        let recordList = this.getRawData().split(this.getSplitByNewLineStr())
+        if (recordList[recordList.length - 1] === '') recordList.pop()
         this.setRawDataList(recordList)
     }
 
@@ -124,64 +133,76 @@ class RecordManager {
     generateRecordObject() {
         var recordObject = {}
         this.getRawDataList().forEach(recordElementList => {
-            if(recordElementList[0] === '$TTL' || recordElementList[0] === '$ORIGIN') 
-                recordObject[recordElementList[0]] = recordElementList[1]            
+            if (recordElementList[0] === '$TTL' || recordElementList[0] === '$ORIGIN')
+                recordObject[recordElementList[0]] = recordElementList[1]
             else {
-                if(recordElementList[2] === 'SOA') 
-                    recordObject[recordElementList[2]] = {
-                        id: recordElementList[recordElementList.length - 1].replace("#", ''),
-                        name: recordElementList[0],
-                        mname: recordElementList[3],
-                        rname: recordElementList[4],
-                        serial: recordElementList[5],
-                        refresh: recordElementList[6],
-                        retry: recordElementList[7],
-                        expire: recordElementList[8],
-                        minimum: recordElementList[9]
+                if (recordElementList[2] === 'SOA')
+                    recordObject[recordElementList[2].toLowerCase()] = {
+                        Options: {
+                            id: recordElementList[recordElementList.length - 1].replace("#", ''),
+                            name: recordElementList[0],
+                            mname: recordElementList[3],
+                            rname: recordElementList[4],
+                            serial: recordElementList[5],
+                            refresh: recordElementList[6],
+                            retry: recordElementList[7],
+                            expire: recordElementList[8],
+                            minimum: recordElementList[9]
+                        }
                     }
                 else {
-                    if(!recordObject[recordElementList[2]]) recordObject[recordElementList[2]] = []
-                    var pattern = {id: recordElementList[recordElementList.length - 1].replace("#", ''),
-                                    name: recordElementList[0]}
-                    
+                    if (!recordObject[recordElementList[2].toLowerCase()]) recordObject[recordElementList[2].toLowerCase()] = []
+                    var pattern = {
+                        id: recordElementList[recordElementList.length - 1].replace("#", ''),
+                        name: recordElementList[0]
+                    }
+
                     switch (recordElementList[2]) {
                         case "NS":
-                            pattern = {...pattern, host: recordElementList[3] }
+                            pattern = { Options: { ...pattern, host: recordElementList[3] } }
                             break;
                         case "MX":
-                            pattern = {...pattern, host: recordElementList[4],
-                                                        preference:recordElementList[3] }
+                            pattern = {
+                                Options: {
+                                    ...pattern, host: recordElementList[4],
+                                    preference: recordElementList[3]
+                                }
+                            }
                             break;
                         case "A":
-                            pattern = {...pattern, host: recordElementList[3] }
+                            pattern = { Options: { ...pattern, host: recordElementList[3] } }
                             break;
                         case "AAAA":
-                            pattern = {...pattern, host: recordElementList[3] }
+                            pattern = { Options: { ...pattern, host: recordElementList[3] } }
                             break;
                         case "CNAME":
-                            pattern = {...pattern, alias: recordElementList[3] }
+                            pattern = { Options: { ...pattern, alias: recordElementList[3] } }
                             break;
                         case "TXT":
-                            pattern = {...pattern, txt: recordElementList[3] }
+                            pattern = { Options: { ...pattern, txt: recordElementList[3] } }
                             break;
                         case "SRV":
-                            pattern = {...pattern, target:recordElementList[6],
-                                                priority:recordElementList[3],
-                                                weight:recordElementList[4],
-                                                port:recordElementList[5] }
+                            pattern = {
+                                Options: {
+                                    ...pattern, target: recordElementList[6],
+                                    priority: recordElementList[3],
+                                    weight: recordElementList[4],
+                                    port: recordElementList[5]
+                                }
+                            }
                             break;
                         default:
                             throw new Error("some record is invalid in record file")
                     }
-                    recordObject[recordElementList[2]].push(pattern)
+                    recordObject[recordElementList[2].toLowerCase()].push(pattern)
                 }
             }
         })
         this.setParsedData(recordObject)
     }
 
-    Parse(dataRaw=undefined) {
-        if(dataRaw) this.setRawData(dataRaw)
+    Parse(dataRaw = undefined) {
+        if (dataRaw) this.setRawData(dataRaw)
         else this.setRawData()
         this.removeComments()
         this.flatten()
@@ -193,18 +214,18 @@ class RecordManager {
     }
 
     Generate(recordObject) {
-        if(!recordObject || typeof recordObject !== "object") throw new Error("invalid Generate function input")
+        if (!recordObject || typeof recordObject !== "object") throw new Error("invalid Generate function input")
         var pattern = this.getGeneratorPattern()
         for (const key in recordObject) {
-            if(key === 'ttl') pattern = pattern.replace("{ttl}", `$TTL ${recordObject.ttl}`)
-            if(key === 'origin') pattern = pattern.replace("{origin}", `$ORIGIN ${recordObject.origin}`)
-            if(key === 'soa') {
+            if (key === 'ttl') pattern = pattern.replace("{ttl}", `$TTL ${recordObject.ttl}`)
+            if (key === 'origin') pattern = pattern.replace("{origin}", `$ORIGIN ${recordObject.origin}`)
+            if (key === 'soa') {
                 var template = this.getRecordTemplate()[key]
                 for (const keyoption in recordObject[key].Options) {
                     template = template.replace(`{${keyoption}}`, recordObject[key].Options[keyoption])
                 }
                 pattern = pattern.replace(`{${key}}`, template)
-            }else{
+            } else {
                 var temp = ""
                 Array.prototype.forEach.call(recordObject[key], record => {
                     var template = this.getRecordTemplate()[key]


### PR DESCRIPTION
feat : possibility to change the newline split for different file format
debug : couldn't generate a new file from basic json data

Feat description :
When using a file format that does newline as '\r\n' and not '\n', the "splitRecords" function wasn't able to split correctly the records. SO I added a possibility to set externally the newline split string.

Debug description :
the "Options" property in the record object wasn't included in the parse to RecordObject, which then wasn't taken into account upon generating new db.local file.
Also, the generated custom Object wasn't the same as the documentation, because of lowercase keys and the "Option" property

This PR close the Issue #1